### PR TITLE
SPA: use koa-connect-history-api-fallback

### DIFF
--- a/lib/local-web-server.js
+++ b/lib/local-web-server.js
@@ -166,13 +166,13 @@ function localWebServer (options) {
 
   /* for any URL not matched by static (e.g. `/search`), serve the SPA */
   if (options.spa) {
-    const historyApiFallback = require('koa-connect-history-api-fallback');
+    const historyApiFallback = require('koa-connect-history-api-fallback')
     debug('SPA', options.spa)
     app.use(historyApiFallback({
       index: options.spa,
       verbose: options.verbose,
       rewrites: options.rewrite
-    }));
+    }))
   }
 
   /* serve static files */

--- a/lib/local-web-server.js
+++ b/lib/local-web-server.js
@@ -164,6 +164,17 @@ function localWebServer (options) {
     }
   })
 
+  /* for any URL not matched by static (e.g. `/search`), serve the SPA */
+  if (options.spa) {
+    const historyApiFallback = require('koa-connect-history-api-fallback');
+    debug('SPA', options.spa)
+    app.use(historyApiFallback({
+      index: options.spa,
+      verbose: options.verbose,
+      rewrites: options.rewrite
+    }));
+  }
+
   /* serve static files */
   if (options.static.root) {
     const serve = require('koa-static')
@@ -176,15 +187,6 @@ function localWebServer (options) {
     app.use(serveIndex(options.serveIndex.path, options.serveIndex.options))
   }
 
-  /* for any URL not matched by static (e.g. `/search`), serve the SPA */
-  if (options.spa) {
-    const send = require('koa-send')
-    debug('SPA', options.spa)
-    app.use(_.all('*', function spa (ctx, route, next) {
-      const root = path.resolve(options.static.root) || process.cwd()
-      return send(ctx, options.spa, { root: root }).then(next)
-    }))
-  }
   return app
 }
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "koa-bodyparser": "^3.0.0",
     "koa-compress": "^1.0.9",
     "koa-conditional-get": "^1.0.3",
+    "koa-connect-history-api-fallback": "^0.3.0",
     "koa-convert": "^1.2.0",
     "koa-etag": "^2.1.1",
     "koa-json": "^1.1.1",


### PR DESCRIPTION
Current SPA mode doesn't work as desired with static assets. 
When the requested file (containing dot chatacter, e. g. `index.js`) does not exist, it redirects to `index.html` instead of 404.

I suggest using [koa-connect-history-api-fallback](https://github.com/davezuko/koa-connect-history-api-fallback) instead, which seems to be appropriate for such cases.
As it is described [here](https://github.com/bripkens/connect-history-api-fallback/issues/21#issuecomment-199144586), we need to place the historyApiFallback before the `static` handler.