### PR TITLE
support binding to a given address only

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ local-web-server is a simple command-line tool. To use it, from your project dir
 <strong>Server</strong>
 
   -p, --port number              Web server port.
+  -a, --address string           Web server address, defaults to localhost.
   -d, --directory path           Root directory, defaults to the current directory.
   -f, --log-format string        If a format is supplied an access log is written to stdout. If
                                  not, a dynamic statistics view is displayed. Use a preset ('none',

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -4,6 +4,10 @@ exports.definitions = [
     description: 'Web server port.', group: 'server'
   },
   {
+    name: 'address', alias: 'a', type: String,
+    description: 'Web server address, defaults to localhost.', group: 'server'
+  },
+  {
     name: 'directory', alias: 'd', type: String, typeLabel: '[underline]{path}',
     description: 'Root directory, defaults to the current directory.', group: 'server'
   },


### PR DESCRIPTION
Also, defaults to listening on localhost by default. Set `--address 0.0.0.0` to
listen on all interfaces.

fixes #55